### PR TITLE
test(heuristic): expand unit tests and add golden partner/opponent cases

### DIFF
--- a/library/tests/heuristic_sorting/BUILD.bazel
+++ b/library/tests/heuristic_sorting/BUILD.bazel
@@ -108,3 +108,27 @@ cc_test(
     copts = DDS_CPPOPTS,
     local_defines = DDS_LOCAL_DEFINES,
 )
+
+cc_test(
+    name = "expanded_golden_tests",
+    srcs = ["expanded_golden_tests.cpp", "test_utils.cpp", "test_utils.h"],
+    deps = [
+        "//library/src/heuristic_sorting:testable_heuristic_sorting",
+        "//library/src/moves:moves",
+        "@googletest//:gtest_main",
+    ],
+    copts = DDS_CPPOPTS,
+    local_defines = DDS_LOCAL_DEFINES,
+)
+
+cc_test(
+    name = "partner_opponent_tests",
+    srcs = ["partner_opponent_tests.cpp", "test_utils.cpp", "test_utils.h"],
+    deps = [
+        "//library/src/heuristic_sorting:testable_heuristic_sorting",
+        "//library/src/moves:moves",
+        "@googletest//:gtest_main",
+    ],
+    copts = DDS_CPPOPTS,
+    local_defines = DDS_LOCAL_DEFINES,
+)

--- a/library/tests/heuristic_sorting/BUILD.bazel
+++ b/library/tests/heuristic_sorting/BUILD.bazel
@@ -7,7 +7,8 @@ cc_test(
     srcs = ["heuristic_sorting_test.cpp"],
     deps = [
         "//library/src/heuristic_sorting:testable_heuristic_sorting",
-        "@googletest//:gtest_main",
+    "@googletest//:gtest_main",
+    "//library/src/moves:moves",
     ],
 )
 
@@ -91,6 +92,18 @@ cc_test(
         "//library/src/heuristic_sorting:testable_heuristic_sorting",
         "//library/src/moves:moves",
         "@googletest//:gtest_main",
+    ],
+    copts = DDS_CPPOPTS,
+    local_defines = DDS_LOCAL_DEFINES,
+)
+
+cc_test(
+    name = "targeted_unit_tests",
+    srcs = ["targeted_unit_tests.cpp" , "test_utils.cpp", "test_utils.h"],
+    deps = [
+        "//library/src/heuristic_sorting:testable_heuristic_sorting",
+    "@googletest//:gtest_main",
+    "//library/src/moves:moves",
     ],
     copts = DDS_CPPOPTS,
     local_defines = DDS_LOCAL_DEFINES,

--- a/library/tests/heuristic_sorting/README.md
+++ b/library/tests/heuristic_sorting/README.md
@@ -1,0 +1,83 @@
+Purpose
+
+Short notes and commands for running the heuristic-sorting test suite and related comparison/fuzz tools.
+
+Prerequisites
+
+- Bazel installed and on PATH
+- A supported C++ toolchain; for coverage generation on macOS you will likely need GNU gcov (brew install gcc) or run coverage in a Linux container/CI
+
+Build with new heuristic enabled
+
+To build the workspace and enable the new heuristic library (this defines the runtime toggle `set_use_new_heuristic`):
+
+```bash
+bazel build //... --define=new_heuristic=true
+```
+
+Run tests (no cached results)
+
+Run the whole heuristic-sorting test suite with the new heuristic and force tests to re-run:
+
+```bash
+bazel test //library/tests/heuristic_sorting:all \
+  --define=new_heuristic=true \
+  --nocache_test_results \
+  --test_output=errors
+```
+
+Run a single test target (faster iteration):
+
+```bash
+bazel test //library/tests/heuristic_sorting:targeted_unit_tests \
+  --define=new_heuristic=true \
+  --nocache_test_results \
+  --test_output=errors
+```
+
+Run the fuzz driver (tests are sandboxed so pass env via --test_env):
+
+```bash
+bazel test //library/tests/heuristic_sorting:fuzz_driver \
+  --define=new_heuristic=true \
+  --nocache_test_results \
+  --test_output=errors \
+  --test_env=FUZZ_SEED=42 \
+  --test_env=FUZZ_ITER=1000
+```
+
+Coverage notes
+
+I attempted a `bazel coverage` run; Bazel invoked `gcov` with flags that do not match the macOS-provided toolchain, producing no coverage data (errors like "gcov: Unknown command line argument '-output'" in the test logs).
+
+Quick fixes:
+
+- Install GNU gcov via Homebrew (recommended on macOS):
+
+```bash
+brew install gcc
+# make gcov point to the GNU one if necessary:
+# ln -s "$(which gcov-13)" "$HOME/bin/gcov"
+# ensure $HOME/bin is first in PATH
+```
+
+- Re-run coverage once gcov is GNU-compatible:
+
+```bash
+bazel coverage //library/tests/heuristic_sorting:all \
+  --define=new_heuristic=true \
+  --nocache_test_results \
+  --test_output=errors
+```
+
+- Alternatively run coverage inside a Linux container/CI where Bazel + GNU toolchain are available.
+
+Notes and best practices
+
+- The test package contains a small comparison harness which can switch between legacy and new implementations when built with `--define=new_heuristic=true` and then `set_use_new_heuristic(...)` is available at runtime.
+- Use `--test_output=all` when debugging tests to capture stdout from gtest.
+- Save golden outputs (normalize ordering JSON) under `build/compare-results` for triage when legacy vs new disagree.
+
+Contact
+
+If you want, I can add more golden unit tests or generate an HTML coverage report once a working gcov is available.

--- a/library/tests/heuristic_sorting/expanded_golden_tests.cpp
+++ b/library/tests/heuristic_sorting/expanded_golden_tests.cpp
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+#include <cstring>
+
+#include "heuristic_sorting/heuristic_sorting.h"
+#include "heuristic_sorting/internal.h"
+#include "test_utils.h"
+#include "moves/Moves.h"
+
+// Expanded golden tests: several handcrafted positions to exercise different
+// branches in the heuristic logic (lead, void, trump, mid-trick).
+
+static void make_moves(moveType* moves, int numMoves) {
+  for (int i = 0; i < numMoves; ++i) {
+    moves[i].suit = i % 4;
+    moves[i].rank = 14 - (i % 13);
+    moves[i].weight = 0;
+    moves[i].sequence = i + 1;
+  }
+}
+
+TEST(ExpandedGolden, LeadAndVoidCases) {
+  pos tpos; memset(&tpos, 0, sizeof(tpos));
+  // North has a singleton in hearts, others balanced
+  tpos.length[0][1] = 1; tpos.length[1][1] = 4; tpos.length[2][1] = 4; tpos.length[3][1] = 4;
+  // some winners
+  tpos.winner[0].rank = 14; tpos.winner[0].hand = 0;
+
+  const int numMoves = 6;
+  moveType moves[numMoves]; make_moves(moves, numMoves);
+
+  moveType bestMove = {}; moveType bestMoveTT = {}; relRanksType rel[1] = {}; trackType track = {};
+
+  set_use_new_heuristic(false);
+  CallHeuristic(tpos, bestMove, bestMoveTT, rel, moves, numMoves, 0, 1, 0, &track, 1, 0, 0, 0);
+  std::string legacy = normalize_ordering(moves, numMoves, true);
+
+  for (int i = 0; i < numMoves; ++i) moves[i].weight = 0;
+
+  set_use_new_heuristic(true);
+  CallHeuristic(tpos, bestMove, bestMoveTT, rel, moves, numMoves, 0, 1, 0, &track, 1, 0, 0, 0);
+  std::string neu = normalize_ordering(moves, numMoves, true);
+
+  EXPECT_EQ(legacy, neu);
+}
+
+TEST(ExpandedGolden, MidTrickRuffing) {
+  pos tpos; memset(&tpos, 0, sizeof(tpos));
+  // Set up a small deal where some cards already played
+  for (int h = 0; h < 4; ++h) for (int s = 0; s < 4; ++s) tpos.length[h][s] = 3;
+  tpos.rankInSuit[0][2] = 0x7000; // A K Q diamonds on hand 0
+
+  const int numMoves = 5;
+  moveType moves[numMoves]; make_moves(moves, numMoves);
+
+  moveType bestMove = {}; moveType bestMoveTT = {}; relRanksType rel[8192]; trackType track = {};
+  init_rel_and_track(tpos, rel, &track, 2, moves, 0, 1);
+
+  set_use_new_heuristic(false);
+  CallHeuristic(tpos, bestMove, bestMoveTT, rel, moves, numMoves, 2, 1, 0, &track, 1, 2, 0, 0);
+  std::string legacy = normalize_ordering(moves, numMoves, true);
+
+  for (int i = 0; i < numMoves; ++i) moves[i].weight = 0;
+
+  set_use_new_heuristic(true);
+  CallHeuristic(tpos, bestMove, bestMoveTT, rel, moves, numMoves, 2, 1, 0, &track, 1, 2, 0, 0);
+  std::string neu = normalize_ordering(moves, numMoves, true);
+
+  EXPECT_EQ(legacy, neu);
+}
+
+TEST(ExpandedGolden, LargeLengths) {
+  pos tpos; memset(&tpos, 0, sizeof(tpos));
+  // Test with long suit lengths to exercise count-based logic
+  tpos.length[0][3] = 7; tpos.length[1][3] = 6; tpos.length[2][3] = 4; tpos.length[3][3] = 2;
+
+  const int numMoves = 7;
+  moveType moves[numMoves]; make_moves(moves, numMoves);
+
+  moveType bestMove = {}; moveType bestMoveTT = {}; relRanksType rel[1] = {}; trackType track = {};
+
+  set_use_new_heuristic(false);
+  CallHeuristic(tpos, bestMove, bestMoveTT, rel, moves, numMoves, 0, 1, 0, &track, 1, 0, 0, 0);
+  std::string legacy = normalize_ordering(moves, numMoves, true);
+
+  for (int i = 0; i < numMoves; ++i) moves[i].weight = 0;
+
+  set_use_new_heuristic(true);
+  CallHeuristic(tpos, bestMove, bestMoveTT, rel, moves, numMoves, 0, 1, 0, &track, 1, 0, 0, 0);
+  std::string neu = normalize_ordering(moves, numMoves, true);
+
+  EXPECT_EQ(legacy, neu);
+}

--- a/library/tests/heuristic_sorting/partner_opponent_tests.cpp
+++ b/library/tests/heuristic_sorting/partner_opponent_tests.cpp
@@ -1,0 +1,75 @@
+#include <gtest/gtest.h>
+#include <cstring>
+
+#include "heuristic_sorting/heuristic_sorting.h"
+#include "heuristic_sorting/internal.h"
+#include "test_utils.h"
+#include "moves/Moves.h"
+
+// Partner and opponent focused golden tests.
+
+static void make_moves(moveType* moves, int numMoves) {
+  for (int i = 0; i < numMoves; ++i) {
+    moves[i].suit = i % 4;
+    moves[i].rank = 14 - (i % 13);
+    moves[i].weight = 0;
+    moves[i].sequence = i + 1;
+  }
+}
+
+TEST(PartnerOpponent, LHO_has_singleton_and_top) {
+  pos tpos; memset(&tpos, 0, sizeof(tpos));
+  // LHO (hand 1) has singleton top in suit 0
+  tpos.length[1][0] = 1; tpos.length[0][0] = 4; tpos.length[2][0] = 4; tpos.length[3][0] = 4;
+  tpos.winner[0].hand = 1; tpos.winner[0].rank = 14;
+
+  const int numMoves = 6; moveType moves[numMoves]; make_moves(moves, numMoves);
+  moveType bm = {}; moveType bmtt = {}; relRanksType rel[1] = {}; trackType track = {};
+
+  set_use_new_heuristic(false);
+  CallHeuristic(tpos, bm, bmtt, rel, moves, numMoves, 0, 1, 0, &track, 1, 0, 0, 0);
+  std::string legacy = normalize_ordering(moves, numMoves, true);
+  for (int i=0;i<numMoves;++i) moves[i].weight = 0;
+  set_use_new_heuristic(true);
+  CallHeuristic(tpos, bm, bmtt, rel, moves, numMoves, 0, 1, 0, &track, 1, 0, 0, 0);
+  std::string neu = normalize_ordering(moves, numMoves, true);
+  EXPECT_EQ(legacy, neu);
+}
+
+TEST(PartnerOpponent, Partner_has_second_highest) {
+  pos tpos; memset(&tpos, 0, sizeof(tpos));
+  // Partner (hand 2) has second highest in suit 1, hand-to-play is 0
+  tpos.length[2][1] = 3; tpos.length[0][1] = 3; tpos.length[1][1] = 3; tpos.length[3][1] = 3;
+  tpos.winner[1].hand = 2; tpos.winner[1].rank = 13; // second highest
+
+  const int numMoves = 5; moveType moves[numMoves]; make_moves(moves, numMoves);
+  moveType bm = {}; moveType bmtt = {}; relRanksType rel[1] = {}; trackType track = {};
+
+  set_use_new_heuristic(false);
+  CallHeuristic(tpos, bm, bmtt, rel, moves, numMoves, 0, 1, 0, &track, 1, 0, 0, 0);
+  std::string legacy = normalize_ordering(moves, numMoves, true);
+  for (int i=0;i<numMoves;++i) moves[i].weight = 0;
+  set_use_new_heuristic(true);
+  CallHeuristic(tpos, bm, bmtt, rel, moves, numMoves, 0, 1, 0, &track, 1, 0, 0, 0);
+  std::string neu = normalize_ordering(moves, numMoves, true);
+  EXPECT_EQ(legacy, neu);
+}
+
+TEST(PartnerOpponent, RHO_raises_and_wins) {
+  pos tpos; memset(&tpos, 0, sizeof(tpos));
+  // RHO (hand 3) will have a raising card in suit 2
+  tpos.length[3][2] = 2; tpos.length[0][2] = 4; tpos.length[1][2] = 4; tpos.length[2][2] = 3;
+  tpos.winner[2].hand = 3; tpos.winner[2].rank = 12;
+
+  const int numMoves = 6; moveType moves[numMoves]; make_moves(moves, numMoves);
+  moveType bm = {}; moveType bmtt = {}; relRanksType rel[1] = {}; trackType track = {};
+
+  set_use_new_heuristic(false);
+  CallHeuristic(tpos, bm, bmtt, rel, moves, numMoves, 0, 1, 0, &track, 1, 0, 0, 0);
+  std::string legacy = normalize_ordering(moves, numMoves, true);
+  for (int i=0;i<numMoves;++i) moves[i].weight = 0;
+  set_use_new_heuristic(true);
+  CallHeuristic(tpos, bm, bmtt, rel, moves, numMoves, 0, 1, 0, &track, 1, 0, 0, 0);
+  std::string neu = normalize_ordering(moves, numMoves, true);
+  EXPECT_EQ(legacy, neu);
+}

--- a/library/tests/heuristic_sorting/targeted_unit_tests.cpp
+++ b/library/tests/heuristic_sorting/targeted_unit_tests.cpp
@@ -55,15 +55,6 @@ TEST(TargetedUnitTests, GetTopNumberEdgeCases) {
   pos tpos = {};
   memset(&tpos, 0, sizeof(tpos));
 
-  // Prepare some dummy moves and call GetTopNumber via Moves wrapper
-  moveType moves[4];
-  for (int i = 0; i < 4; ++i) {
-    moves[i].suit = i % DDS_SUITS;
-    moves[i].rank = 14 - i;
-    moves[i].weight = 0;
-    moves[i].sequence = i + 1;
-  }
-
   int topNumber = -1;
   int mno = -1;
   // Build a small HeuristicContext for GetTopNumber

--- a/library/tests/heuristic_sorting/targeted_unit_tests.cpp
+++ b/library/tests/heuristic_sorting/targeted_unit_tests.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+#include <cstring>
+
+#include "heuristic_sorting/internal.h"
+#include "heuristic_sorting/heuristic_sorting.h"
+#include "test_utils.h"
+#include "moves/Moves.h"
+
+// Targeted unit tests for small helper functions and golden expectations
+
+TEST(TargetedUnitTests, RankForcesAceBasic) {
+  // Construct a minimal context and exercise RankForcesAce for different cards4th
+  pos tpos = {};
+  memset(&tpos, 0, sizeof(tpos));
+
+  // Build a safe HeuristicContext using local objects
+  moveType bm = {};
+  moveType bmtt = {};
+  relRanksType thrp_rel_dummy[1] = {};
+  moveType mply_dummy[1] = {};
+  trackType track_dummy = {};
+
+  HeuristicContext ctx = {
+    tpos,                   // pos
+    bm,                     // bestMove
+    bmtt,                   // bestMoveTT
+    thrp_rel_dummy,         // thrp_rel
+    mply_dummy,             // mply
+    0,                      // numMoves
+    0,                      // lastNumMoves
+    DDS_NOTRUMP,            // trump
+    0,                      // suit
+    &track_dummy,           // trackp
+    0,                      // currTrick
+    0,                      // currHand
+    0,                      // leadHand
+    0                       // leadSuit
+  };
+
+  // Sanity: ensure function is callable and returns in-range values
+  int res0 = RankForcesAce(ctx, 0);
+  int res1 = RankForcesAce(ctx, 1);
+  int res5 = RankForcesAce(ctx, 5);
+
+  // RankForcesAce may return -1 when no forcing rank exists; ensure value is sane
+  EXPECT_GE(res0, -1);
+  EXPECT_GE(res1, -1);
+  EXPECT_GE(res5, -1);
+  EXPECT_LE(res0, 14);
+  EXPECT_LE(res1, 14);
+  EXPECT_LE(res5, 14);
+}
+
+TEST(TargetedUnitTests, GetTopNumberEdgeCases) {
+  pos tpos = {};
+  memset(&tpos, 0, sizeof(tpos));
+
+  // Prepare some dummy moves and call GetTopNumber via Moves wrapper
+  moveType moves[4];
+  for (int i = 0; i < 4; ++i) {
+    moves[i].suit = i % DDS_SUITS;
+    moves[i].rank = 14 - i;
+    moves[i].weight = 0;
+    moves[i].sequence = i + 1;
+  }
+
+  int topNumber = -1;
+  int mno = -1;
+  // Build a small HeuristicContext for GetTopNumber
+  moveType bm = {};
+  moveType bmtt = {};
+  relRanksType thrp_rel_dummy[1] = {};
+  moveType mply_dummy[1] = {};
+  trackType track_dummy = {};
+  HeuristicContext ctx = { tpos, bm, bmtt, thrp_rel_dummy, mply_dummy, 0, 0, DDS_NOTRUMP, 0, &track_dummy, 0, 0, 0, 0 };
+
+  // Call the free helper GetTopNumber from internal.h
+  GetTopNumber(ctx, 0, 14, topNumber, mno);
+  // topNumber may be -1 if no candidate found; ensure values are in expected ranges
+  EXPECT_GE(topNumber, -1);
+  EXPECT_LE(topNumber, 14);
+  EXPECT_GE(mno, 0);
+  EXPECT_LE(mno, 13);
+
+  GetTopNumber(ctx, 5, 10, topNumber, mno);
+  EXPECT_GE(topNumber, -1);
+  EXPECT_LE(topNumber, 14);
+  EXPECT_GE(mno, 0);
+  EXPECT_LE(mno, 13);
+}
+
+TEST(TargetedUnitTests, GoldenOrderingSmallPosition) {
+  // Construct a small position and expected ordering string
+  pos tpos;
+  memset(&tpos, 0, sizeof(tpos));
+
+  tpos.length[0][0] = 4; tpos.length[1][0] = 3; tpos.length[2][0] = 3; tpos.length[3][0] = 3;
+
+  const int numMoves = 5;
+  moveType moves[numMoves];
+  for (int i = 0; i < numMoves; ++i) {
+    moves[i].suit = i % 4;
+    moves[i].rank = 14 - i;
+    moves[i].weight = 0;
+    moves[i].sequence = i + 1;
+  }
+
+  moveType bestMove = {};
+  moveType bestMoveTT = {};
+  relRanksType thrp_rel[1] = {};
+  trackType track = {};
+
+  // Run legacy
+#ifdef DDS_USE_NEW_HEURISTIC
+  set_use_new_heuristic(false);
+#endif
+  CallHeuristic(tpos, bestMove, bestMoveTT, thrp_rel, moves, numMoves,
+                0, 1, 0, &track, 1, 0, 0, 0);
+  std::string legacy = normalize_ordering(moves, numMoves, true);
+
+  // Reset weights
+  for (int i = 0; i < numMoves; ++i) moves[i].weight = 0;
+
+  // Run new
+#ifdef DDS_USE_NEW_HEURISTIC
+  set_use_new_heuristic(true);
+#endif
+  CallHeuristic(tpos, bestMove, bestMoveTT, thrp_rel, moves, numMoves,
+                0, 1, 0, &track, 1, 0, 0, 0);
+  std::string neu = normalize_ordering(moves, numMoves, true);
+
+  EXPECT_EQ(legacy, neu);
+}


### PR DESCRIPTION
Summary

This PR expands unit and golden tests for the new heuristic sorting code and adds a short README for the test folder. The goal is to increase regression coverage for the new heuristic implementation and provide targeted tests that exercise edge cases (rank/force logic, partner/opponent-specific branch behavior) so optimizations can start safely.

What changed

- Added targeted unit tests: library/tests/heuristic_sorting/targeted_unit_tests.cpp (RankForcesAce, GetTopNumber, small golden checks).
- Added expanded golden tests: library/tests/heuristic_sorting/expanded_golden_tests.cpp (lead/void, mid-trick ruffing, long-suit cases).
- Added partner/opponent focused tests: library/tests/heuristic_sorting/partner_opponent_tests.cpp (LHO/RHO/partner scenarios).
- Added library/tests/heuristic_sorting/README.md with build/run/coverage notes.
- Updated library/tests/heuristic_sorting/BUILD.bazel to register the new cc_test targets and deps.

Status / Verification

- Build: bazel build //... --define=new_heuristic=true — completed successfully locally.
- Tests: All heuristic-sorting tests (existing + new targets) pass locally when built with --define=new_heuristic=true.
- Coverage: bazel coverage was attempted but produced no coverage artifacts on macOS due to a gcov/toolchain mismatch. See the README for remediation steps.

Commits & branch

- Branch: chore/expand_heuristic_unit_tests (pushed to origin)
- Commits:
  - a080ef4 — test(heuristic): add targeted unit tests and README for heuristic sorting
  - d845a66 — test(heuristic): add expanded golden and partner/opponent tests

How reviewers can run locally

1) Build with new heuristic enabled:
   bazel build //... --define=new_heuristic=true

2) Run tests:
   bazel test //library/tests/heuristic_sorting:all --define=new_heuristic=true --nocache_test_results --test_output=errors

Notes & suggested next steps

- Add a Linux-based coverage job to CI or run coverage in a container to produce HTML coverage.