### PR TITLE
refactor(system): SearchContext facade and initial search-state routing

### DIFF
--- a/library/src/ABsearch.cpp
+++ b/library/src/ABsearch.cpp
@@ -75,19 +75,20 @@ bool ABsearch(
   bool success = (thrp->nodeTypeStore[hand] == MAXNODE ? true : false);
   bool value = ! success;
 
+  SolverContext ctx{thrp};
 #ifdef DDS_TOP_LEVEL
-  thrp->nodes++;
+  ctx.search().nodes()++;
 #endif
 
   TIMER_START(TIMER_NO_MOVEGEN, depth);
   for (int ss = 0; ss < DDS_SUITS; ss++)
-    thrp->lowestWin[depth][ss] = 0;
+    ctx.search().lowestWin(depth, ss) = 0;
 
   thrp->moves.MoveGen0(
     tricks,
     * posPoint,
-    thrp->bestMove[depth],
-    thrp->bestMoveTT[depth],
+    ctx.search().bestMove(depth),
+    ctx.search().bestMoveTT(depth),
     thrp->rel);
   thrp->moves.Purge(tricks, 0, thrp->forbiddenMoves);
 
@@ -125,7 +126,7 @@ bool ABsearch(
         posPoint->winRanks[depth][ss] =
           posPoint->winRanks[depth - 1][ss];
 
-      thrp->bestMove[depth] = * mply;
+  ctx.search().bestMove(depth) = * mply;
 #ifdef DDS_MOVES
       thrp->moves.RegisterHit(tricks, 0);
 #endif
@@ -166,8 +167,9 @@ bool ABsearch0(
   int hand = posPoint->first[depth];
   int tricks = depth >> 2;
 
+  SolverContext ctx{thrp};
 #ifdef DDS_TOP_LEVEL
-  thrp->nodes++;
+  ctx.search().nodes()++;
 #endif
 
   for (int ss = 0; ss < DDS_SUITS; ss++)
@@ -184,7 +186,6 @@ bool ABsearch0(
 
     bool lowerFlag;
     TIMER_START(TIMER_NO_LOOKUP, depth);
-    SolverContext ctx{thrp};
     nodeCardsType const * cardsP =
       ctx.transTable()->Lookup(
         tricks, hand, posPoint->aggr, posPoint->handDist,
@@ -205,8 +206,8 @@ bool ABsearch0(
 
       if (cardsP->bestMoveRank != 0)
       {
-        thrp->bestMoveTT[depth].suit = cardsP->bestMoveSuit;
-        thrp->bestMoveTT[depth].rank = cardsP->bestMoveRank;
+        ctx.search().bestMoveTT(depth).suit = static_cast<unsigned char>(cardsP->bestMoveSuit);
+        ctx.search().bestMoveTT(depth).rank = static_cast<unsigned char>(cardsP->bestMoveRank);
       }
 
       bool scoreFlag =
@@ -297,7 +298,6 @@ bool ABsearch0(
 
     bool lowerFlag;
     TIMER_START(TIMER_NO_LOOKUP, depth);
-    SolverContext ctx{thrp};
     nodeCardsType const * cardsP =
       ctx.transTable()->Lookup(
         tricks, hand, posPoint->aggr, posPoint->handDist,
@@ -318,8 +318,8 @@ bool ABsearch0(
 
       if (cardsP->bestMoveRank != 0)
       {
-        thrp->bestMoveTT[depth].suit = cardsP->bestMoveSuit;
-        thrp->bestMoveTT[depth].rank = cardsP->bestMoveRank;
+        ctx.search().bestMoveTT(depth).suit = static_cast<unsigned char>(cardsP->bestMoveSuit);
+        ctx.search().bestMoveTT(depth).rank = static_cast<unsigned char>(cardsP->bestMoveRank);
       }
 
       bool scoreFlag =
@@ -335,7 +335,7 @@ bool ABsearch0(
 
   TIMER_START(TIMER_NO_MOVEGEN, depth);
   for (int ss = 0; ss < DDS_SUITS; ss++)
-    thrp->lowestWin[depth][ss] = 0;
+    ctx.search().lowestWin(depth, ss) = 0;
 
   thrp->moves.MoveGen0(
     tricks,
@@ -378,7 +378,7 @@ bool ABsearch0(
         posPoint->winRanks[depth][ss] =
           posPoint->winRanks[depth - 1][ss];
 
-      thrp->bestMove[depth] = * mply;
+    ctx.search().bestMove(depth) = * mply;
 #ifdef DDS_MOVES
       thrp->moves.RegisterHit(tricks, 0);
 #endif
@@ -467,8 +467,9 @@ bool ABsearch1(
   bool value = ! success;
   int tricks = (depth + 3) >> 2;
 
+  SolverContext ctx{thrp};
 #ifdef DDS_TOP_LEVEL
-  thrp->nodes++;
+  ctx.search().nodes()++;
 #endif
 
   TIMER_START(TIMER_NO_QT, depth);
@@ -483,10 +484,10 @@ bool ABsearch1(
 
   TIMER_START(TIMER_NO_MOVEGEN, depth);
   for (int ss = 0; ss < DDS_SUITS; ss++)
-    thrp->lowestWin[depth][ss] = 0;
+    ctx.search().lowestWin(depth, ss) = 0;
 
   thrp->moves.MoveGen123(tricks, 1, * posPoint);
-  if (depth == thrp->iniDepth)
+  if (depth == ctx.search().iniDepth())
     thrp->moves.Purge(tricks, 1, thrp->forbiddenMoves);
 
   TIMER_END(TIMER_NO_MOVEGEN, depth);
@@ -523,7 +524,7 @@ bool ABsearch1(
         posPoint->winRanks[depth][ss] =
           posPoint->winRanks[depth - 1][ss];
 
-      thrp->bestMove[depth] = * mply;
+  ctx.search().bestMove(depth) = * mply;
 #ifdef DDS_MOVES
       thrp->moves.RegisterHit(tricks, 1);
 #endif
@@ -555,16 +556,17 @@ bool ABsearch2(
   bool value = ! success;
   int tricks = (depth + 3) >> 2;
 
+  SolverContext ctx{thrp};
 #ifdef DDS_TOP_LEVEL
-  thrp->nodes++;
+  ctx.search().nodes()++;
 #endif
 
   TIMER_START(TIMER_NO_MOVEGEN, depth);
   for (int ss = 0; ss < DDS_SUITS; ss++)
-    thrp->lowestWin[depth][ss] = 0;
+    ctx.search().lowestWin(depth, ss) = 0;
 
   thrp->moves.MoveGen123(tricks, 2, * posPoint);
-  if (depth == thrp->iniDepth)
+  if (depth == ctx.search().iniDepth())
     thrp->moves.Purge(tricks, 2, thrp->forbiddenMoves);
 
   TIMER_END(TIMER_NO_MOVEGEN, depth);
@@ -603,7 +605,7 @@ bool ABsearch2(
         posPoint->winRanks[depth][ss] =
           posPoint->winRanks[depth - 1][ss];
 
-      thrp->bestMove[depth] = * mply;
+  ctx.search().bestMove(depth) = * mply;
 #ifdef DDS_MOVES
       thrp->moves.RegisterHit(tricks, 2);
 #endif
@@ -638,17 +640,18 @@ bool ABsearch3(
   bool success = (thrp->nodeTypeStore[hand] == MAXNODE ? true : false);
   bool value = ! success;
 
+  SolverContext ctx{thrp};
 #ifdef DDS_TOP_LEVEL
-  thrp->nodes++;
+  ctx.search().nodes()++;
 #endif
 
   TIMER_START(TIMER_NO_MOVEGEN, depth);
   for (int ss = 0; ss < DDS_SUITS; ss++)
-    thrp->lowestWin[depth][ss] = 0;
+    ctx.search().lowestWin(depth, ss) = 0;
   int tricks = (depth + 3) >> 2;
 
   thrp->moves.MoveGen123(tricks, 3, * posPoint);
-  if (depth == thrp->iniDepth)
+  if (depth == ctx.search().iniDepth())
     thrp->moves.Purge(tricks, 3, thrp->forbiddenMoves);
 
   TIMER_END(TIMER_NO_MOVEGEN, depth);
@@ -671,7 +674,7 @@ bool ABsearch3(
 
     Make3(posPoint, makeWinRank, depth, mply, thrp);
 
-    thrp->trickNodes++; // As handRelFirst == 0
+  ctx.search().trickNodes()++; // As handRelFirst == 0
 
     if (thrp->nodeTypeStore[posPoint->first[depth - 1]] == MAXNODE)
       posPoint->tricksMAX++;
@@ -694,7 +697,7 @@ bool ABsearch3(
         posPoint->winRanks[depth][ss] = static_cast<unsigned short>(
                                           posPoint->winRanks[depth - 1][ss] | makeWinRank[ss]);
 
-      thrp->bestMove[depth] = * mply;
+  ctx.search().bestMove(depth) = * mply;
 #ifdef DDS_MOVES
       thrp->moves.RegisterHit(tricks, 3);
 #endif

--- a/library/src/ABsearch.cpp
+++ b/library/src/ABsearch.cpp
@@ -90,7 +90,7 @@ bool ABsearch(
     ctx.search().bestMove(depth),
     ctx.search().bestMoveTT(depth),
     thrp->rel);
-  thrp->moves.Purge(tricks, 0, thrp->forbiddenMoves);
+  thrp->moves.Purge(tricks, 0, ctx.search().forbiddenMoves());
 
   TIMER_END(TIMER_NO_MOVEGEN, depth);
 
@@ -488,7 +488,7 @@ bool ABsearch1(
 
   thrp->moves.MoveGen123(tricks, 1, * posPoint);
   if (depth == ctx.search().iniDepth())
-    thrp->moves.Purge(tricks, 1, thrp->forbiddenMoves);
+    thrp->moves.Purge(tricks, 1, ctx.search().forbiddenMoves());
 
   TIMER_END(TIMER_NO_MOVEGEN, depth);
 
@@ -567,7 +567,7 @@ bool ABsearch2(
 
   thrp->moves.MoveGen123(tricks, 2, * posPoint);
   if (depth == ctx.search().iniDepth())
-    thrp->moves.Purge(tricks, 2, thrp->forbiddenMoves);
+    thrp->moves.Purge(tricks, 2, ctx.search().forbiddenMoves());
 
   TIMER_END(TIMER_NO_MOVEGEN, depth);
 
@@ -652,7 +652,7 @@ bool ABsearch3(
 
   thrp->moves.MoveGen123(tricks, 3, * posPoint);
   if (depth == ctx.search().iniDepth())
-    thrp->moves.Purge(tricks, 3, thrp->forbiddenMoves);
+    thrp->moves.Purge(tricks, 3, ctx.search().forbiddenMoves());
 
   TIMER_END(TIMER_NO_MOVEGEN, depth);
 

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -120,6 +120,10 @@ int& SolverContext::SearchContext::nodes() { return thr_->nodes; }
 int& SolverContext::SearchContext::trickNodes() { return thr_->trickNodes; }
 int& SolverContext::SearchContext::iniDepth() { return thr_->iniDepth; }
 int SolverContext::SearchContext::iniDepth() const { return thr_->iniDepth; }
+moveType* SolverContext::SearchContext::forbiddenMoves() { return thr_->forbiddenMoves; }
+const moveType* SolverContext::SearchContext::forbiddenMoves() const { return thr_->forbiddenMoves; }
+moveType& SolverContext::SearchContext::forbiddenMove(int index) { return thr_->forbiddenMoves[index]; }
+const moveType& SolverContext::SearchContext::forbiddenMove(int index) const { return thr_->forbiddenMoves[index]; }
 
 TransTable* SolverContext::maybeTransTable() const
 {
@@ -161,6 +165,10 @@ void SolverContext::ResetForSolve() const
   }
   for (int t = 0; t < 13; ++t) {
     thr_->winners[t].number = 0;
+  }
+  for (int k = 0; k <= 13; ++k) {
+    thr_->forbiddenMoves[k].rank = 0;
+    thr_->forbiddenMoves[k].suit = 0;
   }
 }
 

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -2,6 +2,7 @@
 
 // Keep dependencies local to this implementation to avoid include churn.
 #include "system/Memory.h"       // for ThreadData definition
+#include "dds/dds.h"             // moveType, WinnersType
 #include "trans_table/TransTableS.h"
 #include "trans_table/TransTableL.h"
 #include "data_types/dds.h" // THREADMEM_* defaults
@@ -90,6 +91,36 @@ TransTable* SolverContext::transTable() const
   return registry()[thr_];
 }
 
+// --- SearchContext out-of-line definitions ---
+unsigned short& SolverContext::SearchContext::lowestWin(int depth, int suit) {
+  return thr_->lowestWin[depth][suit];
+}
+const unsigned short& SolverContext::SearchContext::lowestWin(int depth, int suit) const {
+  return thr_->lowestWin[depth][suit];
+}
+moveType& SolverContext::SearchContext::bestMove(int depth) {
+  return thr_->bestMove[depth];
+}
+const moveType& SolverContext::SearchContext::bestMove(int depth) const {
+  return thr_->bestMove[depth];
+}
+moveType& SolverContext::SearchContext::bestMoveTT(int depth) {
+  return thr_->bestMoveTT[depth];
+}
+const moveType& SolverContext::SearchContext::bestMoveTT(int depth) const {
+  return thr_->bestMoveTT[depth];
+}
+WinnersType& SolverContext::SearchContext::winners(int trickIndex) {
+  return thr_->winners[trickIndex];
+}
+const WinnersType& SolverContext::SearchContext::winners(int trickIndex) const {
+  return thr_->winners[trickIndex];
+}
+int& SolverContext::SearchContext::nodes() { return thr_->nodes; }
+int& SolverContext::SearchContext::trickNodes() { return thr_->trickNodes; }
+int& SolverContext::SearchContext::iniDepth() { return thr_->iniDepth; }
+int SolverContext::SearchContext::iniDepth() const { return thr_->iniDepth; }
+
 TransTable* SolverContext::maybeTransTable() const
 {
   if (!thr_)
@@ -115,6 +146,22 @@ void SolverContext::ResetForSolve() const
 {
   if (auto* tt = maybeTransTable())
     tt->ResetMemory(TT_RESET_FREE_MEMORY);
+  if (!thr_) return;
+  // Reset a subset of search state to a clean slate.
+  thr_->nodes = 0;
+  thr_->trickNodes = 0;
+  for (int d = 0; d < 50; ++d) {
+    thr_->bestMove[d].suit = 0;
+    thr_->bestMove[d].rank = 0;
+    thr_->bestMoveTT[d].suit = 0;
+    thr_->bestMoveTT[d].rank = 0;
+    for (int s = 0; s < DDS_SUITS; ++s) {
+      thr_->lowestWin[d][s] = 0;
+    }
+  }
+  for (int t = 0; t < 13; ++t) {
+    thr_->winners[t].number = 0;
+  }
 }
 
 void SolverContext::ClearTT() const

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -12,6 +12,8 @@
 struct ThreadData;     // defined in system/Memory.h
 struct deal;           // defined in dds/dll.h
 struct futureTricks;   // defined in dds/dll.h
+struct moveType;       // from dds/dds.h
+struct WinnersType;    // from dds/dds.h
 #include "trans_table/TransTable.h" // ensure complete type and enums
 
 // Minimal configuration scaffold for future expansion.
@@ -46,6 +48,28 @@ public:
   void ResetForSolve() const;   // Calls ResetMemory(TT_RESET_FREE_MEMORY)
   void ClearTT() const;         // Calls ReturnAllMemory()
   void ResizeTT(int defMB, int maxMB) const; // Updates sizes if TT exists
+
+  // --- Search state facade ---
+  class SearchContext {
+  public:
+    explicit SearchContext(ThreadData* thr) : thr_(thr) {}
+    unsigned short& lowestWin(int depth, int suit);
+    const unsigned short& lowestWin(int depth, int suit) const;
+    moveType& bestMove(int depth);
+    const moveType& bestMove(int depth) const;
+    moveType& bestMoveTT(int depth);
+    const moveType& bestMoveTT(int depth) const;
+    WinnersType& winners(int trickIndex);
+    const WinnersType& winners(int trickIndex) const;
+    int& nodes();
+    int& trickNodes();
+    int& iniDepth();
+    int iniDepth() const;
+  private:
+    ThreadData* thr_ = nullptr;
+  };
+
+  inline SearchContext search() const { return SearchContext(thr_); }
 
 private:
   ThreadData* thr_ = nullptr;

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -61,6 +61,11 @@ public:
     const moveType& bestMoveTT(int depth) const;
     WinnersType& winners(int trickIndex);
     const WinnersType& winners(int trickIndex) const;
+    // Access to forbidden moves buffer used by Moves::Purge and solver loops
+    moveType* forbiddenMoves();
+    const moveType* forbiddenMoves() const;
+    moveType& forbiddenMove(int index);
+    const moveType& forbiddenMove(int index) const;
     int& nodes();
     int& trickNodes();
     int& iniDepth();


### PR DESCRIPTION
This PR introduces a SearchContext facade within SolverContext and routes a first set of mutable search-state accesses through it.

Summary
- Add SolverContext::SearchContext to encapsulate per-solve mutable search state (nodes, trickNodes, lowestWin, bestMove, bestMoveTT, winners, iniDepth, forbiddenMoves).
- Implement out-of-line definitions in SolverContext.cpp to keep header dependencies minimal; forward-declare heavy types.
- Refactor ABsearch to use ctx.search() for nodes, trickNodes, lowestWin, bestMove, bestMoveTT, iniDepth, and pass forbiddenMoves() to Moves::Purge.
- Extend ResetForSolve() to clear a subset of search state plus TT memory, preserving determinism.

Rationale
- Part of Task 05: migrate search state out of ThreadData towards instance-scoped context. The facade enables incremental, low-risk refactors while keeping behavior identical.

Validation
- bazel test //... passes locally (14/14).
- No public APIs changed.

Follow-ups (next PRs)
- Route remaining search-state fields (e.g., analysis flags and other counters) via the facade.
- Consider moving storage from ThreadData into SolverContext-owned buffers after access sites are centralized.
