### PR TITLE
refactor(system): route SolverIF search-state via facade

### DIFF
--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -480,10 +480,10 @@ int SolveBoardInternal(
     }
     while (lowerbound < upperbound);
 
-    {
-      SolverContext ctx{thrp};
-      ctx.search().bestMove(iniDepth) = mv;
-    }
+
+    SolverContext ctx{thrp};
+    ctx.search().bestMove(iniDepth) = mv;
+  
     if (lowerbound == 0)
     {
       // ALL the other moves must also have payoff 0.
@@ -553,12 +553,10 @@ int SolveBoardInternal(
     else
     {
       futp->cards = 1;
-      {
-        SolverContext ctx{thrp};
-        futp->suit[0] = ctx.search().bestMove(iniDepth).suit;
-        futp->rank[0] = ctx.search().bestMove(iniDepth).rank;
-        futp->equals[0] = ctx.search().bestMove(iniDepth).sequence << 2;
-      }
+      SolverContext ctx{thrp};
+      futp->suit[0] = ctx.search().bestMove(iniDepth).suit;
+      futp->rank[0] = ctx.search().bestMove(iniDepth).rank;
+      futp->equals[0] = ctx.search().bestMove(iniDepth).sequence << 2;
       futp->score[0] = target;
 
       if (solutions != 2)
@@ -616,13 +614,13 @@ int SolveBoardInternal(
     if (! thrp->val)
       break;
 
-    {
-      SolverContext ctx{thrp};
-      futp->cards = ind + 1;
-      futp->suit[ind] = ctx.search().bestMove(iniDepth).suit;
-      futp->rank[ind] = ctx.search().bestMove(iniDepth).rank;
-      futp->equals[ind] = ctx.search().bestMove(iniDepth).sequence << 2;
-    }
+    
+    SolverContext ctx{thrp};
+    futp->cards = ind + 1;
+    futp->suit[ind] = ctx.search().bestMove(iniDepth).suit;
+    futp->rank[ind] = ctx.search().bestMove(iniDepth).rank;
+    futp->equals[ind] = ctx.search().bestMove(iniDepth).sequence << 2;
+    
     futp->score[ind] = futp->score[0];
     ind++;
   }
@@ -630,10 +628,8 @@ int SolveBoardInternal(
 
 SOLVER_STATS:
 
-  {
-    SolverContext ctx{thrp};
-    ctx.search().clearForbiddenMoves();
-  }
+  SolverContext ctx{thrp};
+  ctx.search().clearForbiddenMoves();
 
 #ifdef DDS_TIMING
   thrp->timerList.PrintStats(thrp->fileTimerList.GetStream());

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -627,10 +627,10 @@ int SolveBoardInternal(
 
 
 SOLVER_STATS:
-
-  SolverContext ctx{thrp};
-  ctx.search().clearForbiddenMoves();
-
+  {
+    SolverContext ctx{thrp};
+    ctx.search().clearForbiddenMoves();
+  }
 #ifdef DDS_TIMING
   thrp->timerList.PrintStats(thrp->fileTimerList.GetStream());
 #endif

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -7,10 +7,6 @@
    See LICENSE and README.
 */
 
-#include <iostream>
-#include <iomanip>
-#include <sstream>
-
 #include "SolverIF.h"
 #include "Init.h"
 #include "ABsearch.h"
@@ -20,7 +16,6 @@
 #include "trans_table/TransTable.h"
 #include "system/SolverContext.h"
 #include "dump.h"
-#include "debug.h"
 
 extern System sysdep;
 extern Memory memory;
@@ -166,10 +161,10 @@ int SolveBoardInternal(
 
   moveType mv = {0, 0, 0, 0};
 
-  {
-    SolverContext ctx{thrp};
-    ctx.search().clearForbiddenMoves();
-  }
+  
+  SolverContext ctx{thrp};
+  ctx.search().clearForbiddenMoves();
+  
 
   // ----------------------------------------------------------
   // Consistency checks.
@@ -218,10 +213,9 @@ int SolveBoardInternal(
       reason = TT_RESET_NEW_DEAL;
     else if (newTrump)
       reason = TT_RESET_NEW_TRUMP;
-    {
-      SolverContext ctx{thrp};
-      ctx.transTable()->ResetMemory(reason);
-    }
+    
+    SolverContext ctx{thrp};
+    ctx.transTable()->ResetMemory(reason);
   }
 
   if (newDeal)
@@ -386,10 +380,8 @@ int SolveBoardInternal(
 
       if (lowerbound)
       {
-        {
-          SolverContext ctx{thrp};
-          ctx.search().bestMove(iniDepth) = mv;
-        }
+        SolverContext ctx{thrp};
+        ctx.search().bestMove(iniDepth) = mv;
 
         futp->suit[mno] = mv.suit;
         futp->rank[mno] = mv.rank;
@@ -593,10 +585,9 @@ int SolveBoardInternal(
     {
       moveType const * mp = 
         thrp->moves.MakeNextSimple(trick, handRelFirst);
-      {
-        SolverContext ctx{thrp};
-        ctx.search().forbiddenMove(forb) = * mp;
-      }
+      
+      SolverContext ctx{thrp};
+      ctx.search().forbiddenMove(forb) = * mp;
       forb++;
 
       {
@@ -769,11 +760,9 @@ int SolveSameBoard(
   futp->cards = 1;
   futp->score[0] = lowerbound;
 
-  {
-    SolverContext ctx{thrp};
-    thrp->memUsed = ctx.transTable()->MemoryInUse() +
+  SolverContext ctx{thrp};
+  thrp->memUsed = ctx.transTable()->MemoryInUse() +
                     ThreadMemoryUsed();
-  }
 
 #ifdef DDS_TIMING
   thrp->timerList.PrintStats(thrp->fileTimerList.GetStream());
@@ -940,11 +929,10 @@ int AnalyseLaterBoard(
   futp->score[0] = lowerbound;
   futp->nodes = thrp->trickNodes;
 
-  {
-    SolverContext ctx{thrp};
-    thrp->memUsed = ctx.transTable()->MemoryInUse() +
+  
+  SolverContext ctx{thrp};
+  thrp->memUsed = ctx.transTable()->MemoryInUse() +
                     ThreadMemoryUsed();
-  }
 
 #ifdef DDS_TIMING
   thrp->timerList.PrintStats(thrp->fileTimerList.GetStream());

--- a/library/src/data_types/dds.h
+++ b/library/src/data_types/dds.h
@@ -32,7 +32,6 @@
 #define SIMILARDEALLIMIT 5
 #define SIMILARMAXWINNODES 700000
 
-#define DDS_NOTRUMP 4
 
 /* "hand" is leading hand, "relative" is hand relative leading
 hand.

--- a/library/src/data_types/dll.h
+++ b/library/src/data_types/dll.h
@@ -11,6 +11,8 @@
 #ifndef DDS_DLL_H
 #define DDS_DLL_H
 
+#include "utility/Constants.h"
+
 #if (defined(_WIN32) || defined(__CYGWIN__)) && ! defined(__clang__)
   #define DLLEXPORT __declspec(dllexport)
   #define STDCALL __stdcall
@@ -28,12 +30,6 @@
 
 /* Version 2.9.0. Allowing for 2 digit minor versions */
 #define DDS_VERSION 20900
-
-
-#define DDS_HANDS 4
-#define DDS_SUITS 4
-#define DDS_STRAINS 5
-
 
 #define MAXNOOFBOARDS 200
 

--- a/library/src/heuristic_sorting/heuristic_sorting.h
+++ b/library/src/heuristic_sorting/heuristic_sorting.h
@@ -2,11 +2,6 @@
 
 #include "dds/dds.h"
 
-// Constants
-#define DDS_HANDS 4
-#define DDS_SUITS 4
-#define DDS_NOTRUMP 4
-
 struct trackType
 {
   int leadHand;

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -124,6 +124,12 @@ moveType* SolverContext::SearchContext::forbiddenMoves() { return thr_->forbidde
 const moveType* SolverContext::SearchContext::forbiddenMoves() const { return thr_->forbiddenMoves; }
 moveType& SolverContext::SearchContext::forbiddenMove(int index) { return thr_->forbiddenMoves[index]; }
 const moveType& SolverContext::SearchContext::forbiddenMove(int index) const { return thr_->forbiddenMoves[index]; }
+void SolverContext::SearchContext::clearForbiddenMoves() {
+  for (int k = 0; k <= 13; ++k) {
+    thr_->forbiddenMoves[k].rank = 0;
+    thr_->forbiddenMoves[k].suit = 0;
+  }
+}
 
 TransTable* SolverContext::maybeTransTable() const
 {

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -66,6 +66,7 @@ public:
     const moveType* forbiddenMoves() const;
     moveType& forbiddenMove(int index);
     const moveType& forbiddenMove(int index) const;
+  void clearForbiddenMoves();
     int& nodes();
     int& trickNodes();
     int& iniDepth();

--- a/library/src/utility/Constants.h
+++ b/library/src/utility/Constants.h
@@ -11,8 +11,10 @@
 #define DDS_UTILITY_CONSTANTS_H
 
 // Constants from dll.h
-#define DDS_HANDS 4
-#define DDS_STRAINS 5
+constexpr int DDS_STRAINS = 5;
+constexpr int DDS_HANDS = 4;
+constexpr int DDS_SUITS = 4;
+constexpr int DDS_NOTRUMP = 4;
 
 // Hand relationship arrays
 extern int lho[DDS_HANDS];


### PR DESCRIPTION
This PR continues Task 05 by routing additional search-state access through the SolverContext facade.

Changes
- Add SearchContext::clearForbiddenMoves() helper
- Use ctx.search().bestMove/bestMoveTT when calling MoveGen0 in SolverIF
- Replace direct forbiddenMoves resets/assignments with facade accessors
- Read bestMove via facade when emitting outputs and comparisons

Rationale
- Incremental migration away from direct ThreadData field access keeps changes low risk and reviewable, while centralizing search state behind the facade.

Validation
- bazel test //... passes locally (14/14).

Next slices
- Consider routing additional counters/flags via facade before relocating storage off ThreadData.
