### PR TITLE
refactor(system): route nodeTypeStore via SearchContext

### DIFF
--- a/library/src/ABsearch.cpp
+++ b/library/src/ABsearch.cpp
@@ -72,7 +72,7 @@ bool ABsearch(
 
   int hand = posPoint->first[depth];
   int tricks = depth >> 2;
-  bool success = (thrp->nodeTypeStore[hand] == MAXNODE ? true : false);
+  bool success = (SolverContext{thrp}.search().nodeTypeStore(hand) == MAXNODE ? true : false);
   bool value = ! success;
 
   SolverContext ctx{thrp};
@@ -179,7 +179,7 @@ bool ABsearch0(
   {
     /* Find node that fits the suit lengths */
     int limit;
-    if (thrp->nodeTypeStore[0] == MAXNODE)
+  if (SolverContext{thrp}.search().nodeTypeStore(0) == MAXNODE)
       limit = target - posPoint->tricksMAX - 1;
     else
       limit = tricks - (target - posPoint->tricksMAX - 1);
@@ -211,7 +211,7 @@ bool ABsearch0(
       }
 
       bool scoreFlag =
-        (thrp->nodeTypeStore[0] == MAXNODE ? lowerFlag : ! lowerFlag);
+  (SolverContext{thrp}.search().nodeTypeStore(0) == MAXNODE ? lowerFlag : ! lowerFlag);
 
       AB_COUNT(AB_MAIN_LOOKUP, scoreFlag, depth);
       return scoreFlag;
@@ -249,7 +249,7 @@ bool ABsearch0(
                             trump, res, * thrp);
   TIMER_END(TIMER_NO_QT, depth);
 
-  if (thrp->nodeTypeStore[hand] == MAXNODE)
+  if (SolverContext{thrp}.search().nodeTypeStore(hand) == MAXNODE)
   {
     if (res)
     {
@@ -291,7 +291,7 @@ bool ABsearch0(
   {
     /* Find node that fits the suit lengths */
     int limit;
-    if (thrp->nodeTypeStore[0] == MAXNODE)
+  if (SolverContext{thrp}.search().nodeTypeStore(0) == MAXNODE)
       limit = target - posPoint->tricksMAX - 1;
     else
       limit = tricks - (target - posPoint->tricksMAX - 1);
@@ -323,14 +323,14 @@ bool ABsearch0(
       }
 
       bool scoreFlag =
-        (thrp->nodeTypeStore[0] == MAXNODE ? lowerFlag : ! lowerFlag);
+  (SolverContext{thrp}.search().nodeTypeStore(0) == MAXNODE ? lowerFlag : ! lowerFlag);
 
       AB_COUNT(AB_MAIN_LOOKUP, scoreFlag, depth);
       return scoreFlag;
     }
   }
 
-  bool success = (thrp->nodeTypeStore[hand] == MAXNODE ? true : false);
+  bool success = (SolverContext{thrp}.search().nodeTypeStore(hand) == MAXNODE ? true : false);
   bool value = ! success;
 
   TIMER_START(TIMER_NO_MOVEGEN, depth);
@@ -396,7 +396,7 @@ ABexit:
   nodeCardsType first;
   if (value)
   {
-    if (thrp->nodeTypeStore[0] == MAXNODE)
+  if (SolverContext{thrp}.search().nodeTypeStore(0) == MAXNODE)
     {
       first.ubound = static_cast<char>(tricks + 1);
       first.lbound = static_cast<char>(target - posPoint->tricksMAX);
@@ -410,7 +410,7 @@ ABexit:
   }
   else
   {
-    if (thrp->nodeTypeStore[0] == MAXNODE)
+  if (SolverContext{thrp}.search().nodeTypeStore(0) == MAXNODE)
     {
       first.ubound = static_cast<char>
                      (target - posPoint->tricksMAX - 1);
@@ -428,8 +428,8 @@ ABexit:
   first.bestMoveRank = static_cast<char>(thrp->bestMove[depth].rank);
 
   bool flag =
-    ((thrp->nodeTypeStore[hand] == MAXNODE && value) ||
-     (thrp->nodeTypeStore[hand] == MINNODE && !value))
+  ((SolverContext{thrp}.search().nodeTypeStore(hand) == MAXNODE && value) ||
+   (SolverContext{thrp}.search().nodeTypeStore(hand) == MINNODE && !value))
     ? true : false;
 
   TIMER_START(TIMER_NO_BUILD, depth);
@@ -463,7 +463,7 @@ bool ABsearch1(
 {
   int trump = thrp->trump;
   int hand = handId(posPoint->first[depth], 1);
-  bool success = (thrp->nodeTypeStore[hand] == MAXNODE ? true : false);
+  bool success = (SolverContext{thrp}.search().nodeTypeStore(hand) == MAXNODE ? true : false);
   bool value = ! success;
   int tricks = (depth + 3) >> 2;
 
@@ -552,7 +552,7 @@ bool ABsearch2(
   ThreadData * thrp)
 {
   int hand = handId(posPoint->first[depth], 2);
-  bool success = (thrp->nodeTypeStore[hand] == MAXNODE ? true : false);
+  bool success = (SolverContext{thrp}.search().nodeTypeStore(hand) == MAXNODE ? true : false);
   bool value = ! success;
   int tricks = (depth + 3) >> 2;
 
@@ -676,7 +676,7 @@ bool ABsearch3(
 
   ctx.search().trickNodes()++; // As handRelFirst == 0
 
-    if (thrp->nodeTypeStore[posPoint->first[depth - 1]] == MAXNODE)
+  if (SolverContext{thrp}.search().nodeTypeStore(posPoint->first[depth - 1]) == MAXNODE)
       posPoint->tricksMAX++;
 
     TIMER_START(TIMER_NO_AB, depth - 1);
@@ -686,7 +686,7 @@ bool ABsearch3(
     TIMER_START(TIMER_NO_UNDO, depth);
     Undo0(posPoint, depth, * mply, thrp);
 
-    if (thrp->nodeTypeStore[posPoint->first[depth - 1]] == MAXNODE)
+  if (SolverContext{thrp}.search().nodeTypeStore(posPoint->first[depth - 1]) == MAXNODE)
       posPoint->tricksMAX--;
 
     TIMER_END(TIMER_NO_UNDO, depth);
@@ -1001,7 +1001,8 @@ evalType Evaluate(
       if (count >= 2)
         eval.winRanks[trump] = rmax;
 
-      if (thrp->nodeTypeStore[hmax] == MAXNODE)
+      SolverContext ctx{const_cast<ThreadData*>(thrp)};
+      if (ctx.search().nodeTypeStore(hmax) == MAXNODE)
         goto maxexit;
       else
         goto minexit;
@@ -1034,10 +1035,13 @@ evalType Evaluate(
   if (count >= 2)
     eval.winRanks[k] = rmax;
 
-  if (thrp->nodeTypeStore[hmax] == MAXNODE)
+  {
+    SolverContext ctx{const_cast<ThreadData*>(thrp)};
+    if (ctx.search().nodeTypeStore(hmax) == MAXNODE)
     goto maxexit;
   else
     goto minexit;
+  }
 
 maxexit:
   eval.tricks = posPoint->tricksMAX + 1;

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -229,19 +229,22 @@ int SolveBoardInternal(
   }
   thrp->analysisFlag = false;
 
-  if (handToPlay == 0 || handToPlay == 2)
   {
-    thrp->nodeTypeStore[0] = MAXNODE;
-    thrp->nodeTypeStore[1] = MINNODE;
-    thrp->nodeTypeStore[2] = MAXNODE;
-    thrp->nodeTypeStore[3] = MINNODE;
-  }
-  else
-  {
-    thrp->nodeTypeStore[0] = MINNODE;
-    thrp->nodeTypeStore[1] = MAXNODE;
-    thrp->nodeTypeStore[2] = MINNODE;
-    thrp->nodeTypeStore[3] = MAXNODE;
+    SolverContext ctx{thrp};
+    if (handToPlay == 0 || handToPlay == 2)
+    {
+      ctx.search().nodeTypeStore(0) = MAXNODE;
+      ctx.search().nodeTypeStore(1) = MINNODE;
+      ctx.search().nodeTypeStore(2) = MAXNODE;
+      ctx.search().nodeTypeStore(3) = MINNODE;
+    }
+    else
+    {
+      ctx.search().nodeTypeStore(0) = MINNODE;
+      ctx.search().nodeTypeStore(1) = MAXNODE;
+      ctx.search().nodeTypeStore(2) = MINNODE;
+      ctx.search().nodeTypeStore(3) = MAXNODE;
+    }
   }
 
   for (int k = 0; k < handRelFirst; k++)
@@ -699,19 +702,22 @@ int SolveSameBoard(
 
   thrp->lookAheadPos.first[iniDepth] = dl.first;
 
-  if (dl.first == 0 || dl.first == 2)
   {
-    thrp->nodeTypeStore[0] = MAXNODE;
-    thrp->nodeTypeStore[1] = MINNODE;
-    thrp->nodeTypeStore[2] = MAXNODE;
-    thrp->nodeTypeStore[3] = MINNODE;
-  }
-  else
-  {
-    thrp->nodeTypeStore[0] = MINNODE;
-    thrp->nodeTypeStore[1] = MAXNODE;
-    thrp->nodeTypeStore[2] = MINNODE;
-    thrp->nodeTypeStore[3] = MAXNODE;
+    SolverContext ctx{thrp};
+    if (dl.first == 0 || dl.first == 2)
+    {
+      ctx.search().nodeTypeStore(0) = MAXNODE;
+      ctx.search().nodeTypeStore(1) = MINNODE;
+      ctx.search().nodeTypeStore(2) = MAXNODE;
+      ctx.search().nodeTypeStore(3) = MINNODE;
+    }
+    else
+    {
+      ctx.search().nodeTypeStore(0) = MINNODE;
+      ctx.search().nodeTypeStore(1) = MAXNODE;
+      ctx.search().nodeTypeStore(2) = MINNODE;
+      ctx.search().nodeTypeStore(3) = MAXNODE;
+    }
   }
 
 #ifdef DDS_AB_STATS

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -116,6 +116,8 @@ WinnersType& SolverContext::SearchContext::winners(int trickIndex) {
 const WinnersType& SolverContext::SearchContext::winners(int trickIndex) const {
   return thr_->winners[trickIndex];
 }
+int& SolverContext::SearchContext::nodeTypeStore(int hand) { return thr_->nodeTypeStore[hand]; }
+const int& SolverContext::SearchContext::nodeTypeStore(int hand) const { return thr_->nodeTypeStore[hand]; }
 int& SolverContext::SearchContext::nodes() { return thr_->nodes; }
 int& SolverContext::SearchContext::trickNodes() { return thr_->trickNodes; }
 int& SolverContext::SearchContext::iniDepth() { return thr_->iniDepth; }

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -61,6 +61,9 @@ public:
     const moveType& bestMoveTT(int depth) const;
     WinnersType& winners(int trickIndex);
     const WinnersType& winners(int trickIndex) const;
+  // Node type store for each hand (MAXNODE/MINNODE)
+  int& nodeTypeStore(int hand);
+  const int& nodeTypeStore(int hand) const;
     // Access to forbidden moves buffer used by Moves::Purge and solver loops
     moveType* forbiddenMoves();
     const moveType* forbiddenMoves() const;


### PR DESCRIPTION
This PR continues Task 05 by routing `nodeTypeStore` usage through the `SolverContext::SearchContext` facade.

Changes
- Add `SearchContext::nodeTypeStore(int)` accessors
- Replace direct reads/writes of `thrp->nodeTypeStore[...]` in ABsearch and SolverIF
- Handle const ThreadData* in `Evaluate` with a local ctx for read-only access

Why
- Consolidates search-state access behind the facade, reducing direct coupling to `ThreadData` and preparing for future storage relocation.

Validation
- `bazel test //...` passes locally (14/14).

Next slices
- Route remaining search-state fields (e.g., analysisFlag or other counters) via the facade before considering storage movement.
