### PR TITLE
refactor(system): add analysisFlag facade and route SolverIF usage

### DIFF
--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -223,11 +223,14 @@ int SolveBoardInternal(
     SetDeal(thrp);
     SetDealTables(thrp);
   }
-  else if (thrp->analysisFlag)
+  else if (SolverContext{thrp}.search().analysisFlag())
   {
     SetDeal(thrp);
   }
-  thrp->analysisFlag = false;
+  {
+    SolverContext ctx{thrp};
+    ctx.search().analysisFlag() = false;
+  }
 
   {
     SolverContext ctx{thrp};
@@ -829,7 +832,10 @@ int AnalyseLaterBoard(
   int trick = (iniDepth + 3) >> 2;
   int handRelFirst = (48 - iniDepth) % 4;
   thrp->trickNodes = 0;
-  thrp->analysisFlag = true;
+  {
+    SolverContext ctx{thrp};
+    ctx.search().analysisFlag() = true;
+  }
   int handToPlay = handId(leadHand, handRelFirst);
 
   if (handToPlay == 0 || handToPlay == 2)

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -92,6 +92,8 @@ TransTable* SolverContext::transTable() const
 }
 
 // --- SearchContext out-of-line definitions ---
+bool& SolverContext::SearchContext::analysisFlag() { return thr_->analysisFlag; }
+bool SolverContext::SearchContext::analysisFlag() const { return thr_->analysisFlag; }
 unsigned short& SolverContext::SearchContext::lowestWin(int depth, int suit) {
   return thr_->lowestWin[depth][suit];
 }
@@ -162,6 +164,7 @@ void SolverContext::ResetForSolve() const
   // Reset a subset of search state to a clean slate.
   thr_->nodes = 0;
   thr_->trickNodes = 0;
+  thr_->analysisFlag = false;
   for (int d = 0; d < 50; ++d) {
     thr_->bestMove[d].suit = 0;
     thr_->bestMove[d].rank = 0;

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -53,6 +53,9 @@ public:
   class SearchContext {
   public:
     explicit SearchContext(ThreadData* thr) : thr_(thr) {}
+    // analysis flag used to control incremental analysis behavior
+    bool& analysisFlag();
+    bool analysisFlag() const;
     unsigned short& lowestWin(int depth, int suit);
     const unsigned short& lowestWin(int depth, int suit) const;
     moveType& bestMove(int depth);


### PR DESCRIPTION
This PR continues Task 05 by migrating another small piece of search state through the facade.

Changes
- Add SearchContext accessors for `analysisFlag` (get/set) [if not already present]
- Replace direct `thrp->analysisFlag` resets/reads in SolverIF with `ctx.search().analysisFlag()`

Rationale
- Incremental migration keeps changes reviewable while centralizing search state behind the facade.

Validation
- `bazel test //...` passes locally.

Follow-ups
- Route any remaining search-state scalars via the facade, then evaluate storage relocation off `ThreadData`.
