### PR TITLE
refactor(movegen): encapsulate move generation via SolverContext (Task 06)

### DIFF
--- a/library/src/ABsearch.cpp
+++ b/library/src/ABsearch.cpp
@@ -105,13 +105,13 @@ bool ABsearch(
   for (int ss = 0; ss < DDS_SUITS; ss++)
     ctx.search().lowestWin(depth, ss) = 0;
 
-  thrp->moves.MoveGen0(
+  ctx.moveGen().MoveGen0(
     tricks,
     * posPoint,
     ctx.search().bestMove(depth),
     ctx.search().bestMoveTT(depth),
     thrp->rel);
-  thrp->moves.Purge(tricks, 0, ctx.search().forbiddenMoves());
+  ctx.moveGen().Purge(tricks, 0, ctx.search().forbiddenMoves());
 
   TIMER_END(TIMER_NO_MOVEGEN, depth);
 
@@ -121,7 +121,7 @@ bool ABsearch(
   while (1)
   {
     TIMER_START(TIMER_NO_MAKE, depth);
-    moveType const * mply = thrp->moves.MakeNext(tricks, 0,
+    moveType const * mply = ctx.moveGen().MakeNext(tricks, 0,
       posPoint->winRanks[depth]);
 #ifdef DDS_AB_STATS
     thrp->ABStats.IncrNode(depth);
@@ -149,7 +149,7 @@ bool ABsearch(
 
   ctx.search().bestMove(depth) = * mply;
 #ifdef DDS_MOVES
-      thrp->moves.RegisterHit(tricks, 0);
+  ctx.moveGen().RegisterHit(tricks, 0);
 #endif
       goto ABexit;
     }
@@ -367,7 +367,7 @@ static bool ABsearch0_ctx(
   for (int ss = 0; ss < DDS_SUITS; ss++)
     ctx.search().lowestWin(depth, ss) = 0;
 
-  thrp->moves.MoveGen0(
+  ctx.moveGen().MoveGen0(
     tricks,
     * posPoint,
     ctx.search().bestMove(depth),
@@ -382,7 +382,7 @@ static bool ABsearch0_ctx(
   while (1)
   {
     TIMER_START(TIMER_NO_MAKE, depth);
-    moveType const * mply = thrp->moves.MakeNext(tricks, 0,
+    moveType const * mply = ctx.moveGen().MakeNext(tricks, 0,
       posPoint->winRanks[depth]);
 #ifdef DDS_AB_STATS
     thrp->ABStats.IncrNode(depth);
@@ -410,7 +410,7 @@ static bool ABsearch0_ctx(
 
       ctx.search().bestMove(depth) = * mply;
 #ifdef DDS_MOVES
-      thrp->moves.RegisterHit(tricks, 0);
+  ctx.moveGen().RegisterHit(tricks, 0);
 #endif
       goto ABexit;
     }
@@ -523,9 +523,9 @@ static bool ABsearch1_ctx(
   for (int ss = 0; ss < DDS_SUITS; ss++)
     ctx.search().lowestWin(depth, ss) = 0;
 
-  thrp->moves.MoveGen123(tricks, 1, * posPoint);
+  ctx.moveGen().MoveGen123(tricks, 1, * posPoint);
   if (depth == ctx.search().iniDepth())
-    thrp->moves.Purge(tricks, 1, ctx.search().forbiddenMoves());
+  ctx.moveGen().Purge(tricks, 1, ctx.search().forbiddenMoves());
 
   TIMER_END(TIMER_NO_MOVEGEN, depth);
 
@@ -535,7 +535,7 @@ static bool ABsearch1_ctx(
   while (1)
   {
     TIMER_START(TIMER_NO_MAKE, depth);
-    moveType const * mply = thrp->moves.MakeNext(tricks, 1, posPoint->winRanks[depth]);
+  moveType const * mply = ctx.moveGen().MakeNext(tricks, 1, posPoint->winRanks[depth]);
 #ifdef DDS_AB_STATS
     thrp->ABStats.IncrNode(depth);
 #endif
@@ -561,7 +561,7 @@ static bool ABsearch1_ctx(
 
       ctx.search().bestMove(depth) = * mply;
 #ifdef DDS_MOVES
-      thrp->moves.RegisterHit(tricks, 1);
+  ctx.moveGen().RegisterHit(tricks, 1);
 #endif
       goto ABexit;
     }
@@ -609,9 +609,9 @@ static bool ABsearch2_ctx(
   for (int ss = 0; ss < DDS_SUITS; ss++)
     ctx.search().lowestWin(depth, ss) = 0;
 
-  thrp->moves.MoveGen123(tricks, 2, * posPoint);
+  ctx.moveGen().MoveGen123(tricks, 2, * posPoint);
   if (depth == ctx.search().iniDepth())
-    thrp->moves.Purge(tricks, 2, ctx.search().forbiddenMoves());
+  ctx.moveGen().Purge(tricks, 2, ctx.search().forbiddenMoves());
 
   TIMER_END(TIMER_NO_MOVEGEN, depth);
 
@@ -621,7 +621,7 @@ static bool ABsearch2_ctx(
   while (1)
   {
     TIMER_START(TIMER_NO_MAKE, depth);
-    moveType const * mply = thrp->moves.MakeNext(tricks, 2, posPoint->winRanks[depth]);
+  moveType const * mply = ctx.moveGen().MakeNext(tricks, 2, posPoint->winRanks[depth]);
 
     if (mply == NULL)
       break;
@@ -648,7 +648,7 @@ static bool ABsearch2_ctx(
 
       ctx.search().bestMove(depth) = * mply;
 #ifdef DDS_MOVES
-      thrp->moves.RegisterHit(tricks, 2);
+  ctx.moveGen().RegisterHit(tricks, 2);
 #endif
       goto ABexit;
     }
@@ -700,9 +700,9 @@ static bool ABsearch3_ctx(
     ctx.search().lowestWin(depth, ss) = 0;
   int tricks = (depth + 3) >> 2;
 
-  thrp->moves.MoveGen123(tricks, 3, * posPoint);
+  ctx.moveGen().MoveGen123(tricks, 3, * posPoint);
   if (depth == ctx.search().iniDepth())
-    thrp->moves.Purge(tricks, 3, ctx.search().forbiddenMoves());
+  ctx.moveGen().Purge(tricks, 3, ctx.search().forbiddenMoves());
 
   TIMER_END(TIMER_NO_MOVEGEN, depth);
 
@@ -712,7 +712,7 @@ static bool ABsearch3_ctx(
   while (1)
   {
     TIMER_START(TIMER_NO_MAKE, depth);
-    moveType const * mply = thrp->moves.MakeNext(tricks, 3, posPoint->winRanks[depth]);
+  moveType const * mply = ctx.moveGen().MakeNext(tricks, 3, posPoint->winRanks[depth]);
 #ifdef DDS_AB_STATS
     thrp->ABStats.IncrNode(depth);
 #endif
@@ -748,7 +748,7 @@ static bool ABsearch3_ctx(
 
       ctx.search().bestMove(depth) = * mply;
 #ifdef DDS_MOVES
-      thrp->moves.RegisterHit(tricks, 3);
+  ctx.moveGen().RegisterHit(tricks, 3);
 #endif
       goto ABexit;
     }
@@ -1114,7 +1114,7 @@ evalType Evaluate(
   const int trump,
   ThreadData const * thrp)
 {
-  SolverContext ctx{const_cast<ThreadData*>(thrp)};
+  SolverContext ctx{thrp};
   return EvaluateWithContext(posPoint, trump, ctx);
 }
 

--- a/library/src/ABsearch.cpp
+++ b/library/src/ABsearch.cpp
@@ -472,7 +472,7 @@ ABexit:
 
 #ifdef DDS_AB_HITS
   DumpStored(thrp->fileStored.GetStream(), 
-    * posPoint, thrp->moves, first, target, depth);
+    * posPoint, ctx, first, target, depth);
 #endif
 
   AB_COUNT(AB_MOVE_LOOP, value, depth);

--- a/library/src/ABsearch.cpp
+++ b/library/src/ABsearch.cpp
@@ -11,14 +11,12 @@
 
 #include "trans_table/TransTable.h"
 #include "system/SolverContext.h"
-#include "moves/Moves.h"
 #include "QuickTricks.h"
 #include "LaterTricks.h"
 #include "ABsearch.h"
 #include "ABstats.h"
 #include "system/TimerList.h"
 #include "dump.h"
-#include "debug.h"
 
 // Internal ctx-enabled variants (forward declarations)
 static bool ABsearch0_ctx(pos * posPoint, int target, int depth, ThreadData * thrp, SolverContext& ctx);

--- a/library/src/ABsearch.cpp
+++ b/library/src/ABsearch.cpp
@@ -831,9 +831,10 @@ void Make3(
   moveType const * mply,
   ThreadData * thrp)
 {
+  SolverContext ctx{thrp};
   int firstHand = posPoint->first[depth];
 
-  const trickDataType& data = thrp->moves.GetTrickData((depth + 3) >> 2);
+  const trickDataType& data = ctx.moveGen().GetTrickData((depth + 3) >> 2);
 
   posPoint->first[depth - 1] = handId(firstHand, data.relWinner);
   /* Defines who is first in the next move */
@@ -899,7 +900,7 @@ static void Make3_ctx(
 {
   int firstHand = posPoint->first[depth];
 
-  const trickDataType& data = thrp->moves.GetTrickData((depth + 3) >> 2);
+  const trickDataType& data = ctx.moveGen().GetTrickData((depth + 3) >> 2);
 
   posPoint->first[depth - 1] = handId(firstHand, data.relWinner);
   /* Defines who is first in the next move */

--- a/library/src/ABsearch.cpp
+++ b/library/src/ABsearch.cpp
@@ -962,7 +962,8 @@ void Make3Simple(
   moveType const * mply,
   ThreadData * thrp)
 {
-  const trickDataType& data = thrp->moves.GetTrickData((depth + 3) >> 2);
+  SolverContext ctx{thrp};
+  const trickDataType& data = ctx.moveGen().GetTrickData((depth + 3) >> 2);
 
   int firstHand = posPoint->first[depth];
 

--- a/library/src/LaterTricks.cpp
+++ b/library/src/LaterTricks.cpp
@@ -35,7 +35,7 @@ bool LaterTricksMIN(
   const int trump,
   const ThreadData& thrd)
 {
-  SolverContext ctx{const_cast<ThreadData*>(&thrd)};
+  SolverContext ctx{&thrd};
   if ((trump == DDS_NOTRUMP) || (tpos.winner[trump].rank == 0))
   {
     int sum = 0;
@@ -183,7 +183,7 @@ bool LaterTricksMAX(
   const int trump,
   const ThreadData& thrd)
 {
-  SolverContext ctx{const_cast<ThreadData*>(&thrd)};
+  SolverContext ctx{&thrd};
   if ((trump == DDS_NOTRUMP) || (tpos.winner[trump].rank == 0))
   {
     int sum = 0;

--- a/library/src/QuickTricks.cpp
+++ b/library/src/QuickTricks.cpp
@@ -106,7 +106,7 @@ int QuickTricks(
   bool& result,
   const ThreadData& thrd)
 {
-  SolverContext ctx{const_cast<ThreadData*>(&thrd)};
+  SolverContext ctx{&thrd};
   int suit, commRank = 0, commSuit = -1;
   int res;
   int lhoTrumpRanks = 0, rhoTrumpRanks = 0;
@@ -1120,7 +1120,7 @@ bool QuickTricksSecondHand(
   const int trump,
   const ThreadData& thrd)
 {
-  SolverContext ctx{const_cast<ThreadData*>(&thrd)};
+  SolverContext ctx{&thrd};
   if (depth == ctx.search().iniDepth())
     return false;
 

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -787,11 +787,11 @@ int SolveSameBoard(
 #endif
 
 #ifdef DDS_MOVES
-  thrp->moves.PrintTrickStats(thrp->fileMoves.GetStream());
+  ctxSame.moveGen().PrintTrickStats(thrp->fileMoves.GetStream());
 #ifdef DDS_MOVES_DETAILS
-  thrp->moves.PrintTrickDetails(thrp->fileMoves.GetStream());
+  ctxSame.moveGen().PrintTrickDetails(thrp->fileMoves.GetStream());
 #endif
-  thrp->moves.PrintFunctionStats(thrp->fileMoves.GetStream());
+  ctxSame.moveGen().PrintFunctionStats(thrp->fileMoves.GetStream());
 #endif
 
   {
@@ -967,11 +967,11 @@ int AnalyseLaterBoard(
 #endif
 
 #ifdef DDS_MOVES
-  thrp->moves.PrintTrickStats(thrp->fileMoves.GetStream());
+  ctxLater.moveGen().PrintTrickStats(thrp->fileMoves.GetStream());
 #ifdef DDS_MOVES_DETAILS
-  thrp->moves.PrintTrickDetails(thrp->fileMoves.GetStream());
+  ctxLater.moveGen().PrintTrickDetails(thrp->fileMoves.GetStream());
 #endif
-  thrp->moves.PrintFunctionStats(thrp->fileMoves.GetStream());
+  ctxLater.moveGen().PrintFunctionStats(thrp->fileMoves.GetStream());
 #endif
 
 #ifdef DDS_MEMORY_LEAKS_WIN32

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -727,7 +727,7 @@ int SolveSameBoard(
   }
 #endif
 
-  thrp->moves.Reinit(trick, dl.first);
+  ctxSame.moveGen().Reinit(trick, dl.first);
 
   int guess = hint;
   int lowerbound = 0;

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -323,7 +323,7 @@ int SolveBoardInternal(
 
   if (mode == 0 && noMoves == 1)
   {
-    moveType const * mp = thrp->moves.MakeNextSimple(trick, handRelFirst);
+  moveType const * mp = ctx.moveGen().MakeNextSimple(trick, handRelFirst);
 
     futp->nodes = 0;
     futp->cards = 1;
@@ -400,7 +400,7 @@ int SolveBoardInternal(
         for (int j = 0; j < noLeft; j++)
         {
           moveType const * mp = 
-            thrp->moves.MakeNextSimple(trick, handRelFirst);
+            ctx.moveGen().MakeNextSimple(trick, handRelFirst);
 
           futp->suit[mno + j] = mp->suit;
           futp->rank[mno + j] = mp->rank;

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -652,6 +652,7 @@ SOLVER_STATS:
   }
 #endif
 
+// Diagnostics are routed via the SolverContext MoveGen facade.
 #ifdef DDS_MOVES
   ctx.moveGen().PrintTrickStats(thrp->fileMoves.GetStream());
 #ifdef DDS_MOVES_DETAILS
@@ -966,6 +967,7 @@ int AnalyseLaterBoard(
   }
 #endif
 
+// Diagnostics are routed via the SolverContext MoveGen facade.
 #ifdef DDS_MOVES
   ctxLater.moveGen().PrintTrickStats(thrp->fileMoves.GetStream());
 #ifdef DDS_MOVES_DETAILS

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -503,7 +503,7 @@ int SolveBoardInternal(
       for (int i = 0; i < noMoves; i++)
       {
         moveType const * mp = 
-          thrp->moves.MakeNextSimple(trick, handRelFirst);
+          ctx.moveGen().MakeNextSimple(trick, handRelFirst);
 
         futp->score[i] = 0;
         futp->suit[i] = mp->suit;
@@ -587,7 +587,7 @@ int SolveBoardInternal(
     for (int k = 0; k < num; k++)
     {
       moveType const * mp = 
-        thrp->moves.MakeNextSimple(trick, handRelFirst);
+        ctx.moveGen().MakeNextSimple(trick, handRelFirst);
       
       ctx.search().forbiddenMove(forb) = * mp;
       forb++;

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -261,7 +261,7 @@ int SolveBoardInternal(
 
     if (k == 0)
     {
-      thrp->moves.MoveGen0(
+      ctx.moveGen().MoveGen0(
         trick,
         thrp->lookAheadPos,
         ctx.search().bestMove(iniDepth),
@@ -269,7 +269,7 @@ int SolveBoardInternal(
         thrp->rel);
     }
     else
-      thrp->moves.MoveGen123(
+      ctx.moveGen().MoveGen123(
         trick,
         k,
         thrp->lookAheadPos);
@@ -302,7 +302,7 @@ int SolveBoardInternal(
 
   if (handRelFirst == 0)
   {
-    thrp->moves.MoveGen0(
+    ctx.moveGen().MoveGen0(
       trick,
       thrp->lookAheadPos,
       ctx.search().bestMove(iniDepth),
@@ -310,12 +310,12 @@ int SolveBoardInternal(
       thrp->rel);
   }
   else
-    thrp->moves.MoveGen123(
+    ctx.moveGen().MoveGen123(
       trick,
       handRelFirst,
       thrp->lookAheadPos);
 
-  noMoves = thrp->moves.GetLength(trick, handRelFirst);
+  noMoves = ctx.moveGen().GetLength(trick, handRelFirst);
 
   // ----------------------------------------------------------
   // mode == 0: Check whether there is only one possible move
@@ -394,9 +394,9 @@ int SolveBoardInternal(
       }
       else
       {
-        int noLeft = thrp->moves.GetLength(trick, handRelFirst);
+  int noLeft = ctx.moveGen().GetLength(trick, handRelFirst);
 
-        thrp->moves.Rewind(trick, handRelFirst);
+  ctx.moveGen().Rewind(trick, handRelFirst);
         for (int j = 0; j < noLeft; j++)
         {
           moveType const * mp = 
@@ -499,7 +499,7 @@ int SolveBoardInternal(
       else // solutions == 2, so return all cards
         futp->cards = noMoves;
 
-      thrp->moves.Rewind(trick, handRelFirst);
+  ctx.moveGen().Rewind(trick, handRelFirst);
       for (int i = 0; i < noMoves; i++)
       {
         moveType const * mp = 
@@ -581,8 +581,8 @@ int SolveBoardInternal(
   {
     // Moves up to and including bestMove are now forbidden.
 
-    thrp->moves.Rewind(trick, handRelFirst);
-    int num = thrp->moves.GetLength(trick, handRelFirst);
+  ctx.moveGen().Rewind(trick, handRelFirst);
+  int num = ctx.moveGen().GetLength(trick, handRelFirst);
 
     for (int k = 0; k < num; k++)
     {
@@ -1089,7 +1089,7 @@ int BoardValueChecks(
   const int mode,
   ThreadData const * thrp)
 {
-  SolverContext ctx{const_cast<ThreadData*>(thrp)};
+  SolverContext ctx{thrp};
   int cardCount = ctx.search().iniDepth() + 4;
   if (cardCount <= 0)
   {

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -655,7 +655,7 @@ SOLVER_STATS:
 #ifdef DDS_MOVES
   ctx.moveGen().PrintTrickStats(thrp->fileMoves.GetStream());
 #ifdef DDS_MOVES_DETAILS
-  thrp->moves.PrintTrickDetails(thrp->fileMoves.GetStream());
+  ctx.moveGen().PrintTrickDetails(thrp->fileMoves.GetStream());
 #endif
   ctx.moveGen().PrintFunctionStats(thrp->fileMoves.GetStream());
 #endif

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -853,7 +853,7 @@ int AnalyseLaterBoard(
 
   if (handRelFirst == 0)
   {
-    thrp->moves.MakeSpecific(* move, trick + 1, 3);
+    ctxLater.moveGen().MakeSpecific(* move, trick + 1, 3);
     unsigned short int ourWinRanks[DDS_SUITS]; // Unused here
     Make3(&thrp->lookAheadPos, ourWinRanks, iniDepth + 1, move, thrp);
   }

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -859,12 +859,12 @@ int AnalyseLaterBoard(
   }
   else if (handRelFirst == 1)
   {
-    thrp->moves.MakeSpecific(* move, trick, 0);
+    ctxLater.moveGen().MakeSpecific(* move, trick, 0);
     Make0(&thrp->lookAheadPos, iniDepth + 1, move);
   }
   else if (handRelFirst == 2)
   {
-    thrp->moves.MakeSpecific(* move, trick, 1);
+    ctxLater.moveGen().MakeSpecific(* move, trick, 1);
     Make1(&thrp->lookAheadPos, iniDepth + 1, move);
   }
   else

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -426,7 +426,7 @@ int SolveBoardInternal(
     for (int mno = 0; mno < noMoves; mno++)
     {
       moveType const * mp = 
-        thrp->moves.MakeNextSimple(trick, handRelFirst);
+        ctx.moveGen().MakeNextSimple(trick, handRelFirst);
 
       futp->suit[mno] = mp->suit;
       futp->rank[mno] = mp->rank;

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -653,11 +653,11 @@ SOLVER_STATS:
 #endif
 
 #ifdef DDS_MOVES
-  thrp->moves.PrintTrickStats(thrp->fileMoves.GetStream());
+  ctx.moveGen().PrintTrickStats(thrp->fileMoves.GetStream());
 #ifdef DDS_MOVES_DETAILS
   thrp->moves.PrintTrickDetails(thrp->fileMoves.GetStream());
 #endif
-  thrp->moves.PrintFunctionStats(thrp->fileMoves.GetStream());
+  ctx.moveGen().PrintFunctionStats(thrp->fileMoves.GetStream());
 #endif
 
 SOLVER_DONE:

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -250,7 +250,7 @@ int SolveBoardInternal(
     mv.suit = dl.currentTrickSuit[k];
     mv.sequence = 0;
 
-    thrp->moves.Init(
+    ctx.moveGen().Init(
       trick,
       k,
       dl.currentTrickRank,
@@ -291,7 +291,7 @@ int SolveBoardInternal(
   }
 #endif
 
-  thrp->moves.Init(
+  ctx.moveGen().Init(
     trick,
     handRelFirst,
     dl.currentTrickRank,

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -869,7 +869,7 @@ int AnalyseLaterBoard(
   }
   else
   {
-    thrp->moves.MakeSpecific(* move, trick, 2);
+    ctxLater.moveGen().MakeSpecific(* move, trick, 2);
     Make2(&thrp->lookAheadPos, iniDepth + 1, move);
   }
 

--- a/library/src/SolverIF.cpp
+++ b/library/src/SolverIF.cpp
@@ -274,8 +274,8 @@ int SolveBoardInternal(
         k,
         thrp->lookAheadPos);
 
-    thrp->lookAheadPos.move[iniDepth + handRelFirst - k] = mv;
-    thrp->moves.MakeSpecific(mv, trick, k);
+  thrp->lookAheadPos.move[iniDepth + handRelFirst - k] = mv;
+  ctx.moveGen().MakeSpecific(mv, trick, k);
   }
 
   InitWinners(dl, thrp->lookAheadPos, thrp);

--- a/library/src/dump.cpp
+++ b/library/src/dump.cpp
@@ -225,7 +225,7 @@ string DumpTopHeader(
   const int printMode)
 {
   // Use facade to read search-state safely
-  SolverContext ctx{const_cast<ThreadData*>(&thrd)};
+  SolverContext ctx{&thrd};
   string stext;
   if (printMode == 0)
   {
@@ -358,7 +358,7 @@ void DumpTopLevel(
   const int printMode)
 {
   const pos& tpos = thrd.lookAheadPos;
-  SolverContext ctx{const_cast<ThreadData*>(&thrd)};
+  SolverContext ctx{&thrd};
 
   fout << DumpTopHeader(thrd, tricks, lower, upper, printMode) << "\n";
   fout << PrintDeal(tpos.rankInSuit, 16);

--- a/library/src/dump.cpp
+++ b/library/src/dump.cpp
@@ -348,6 +348,22 @@ void DumpStored(
   fout << PrintDeal(tpos.rankInSuit, 16);
 }
 
+void DumpStored(
+  ofstream& fout,
+  const pos& tpos,
+  SolverContext& ctx,
+  const nodeCardsType& node,
+  const int target,
+  const int depth)
+{
+  fout << "Stored entry\n";
+  fout << string(12, '-') << "\n";
+  fout << PosToText(tpos, target, depth) << "\n";
+  fout << NodeToText(node);
+  fout << ctx.moveGen().TrickToText((depth >> 2) + 1) << "\n";
+  fout << PrintDeal(tpos.rankInSuit, 16);
+}
+
 
 void DumpTopLevel(
   ofstream& fout,

--- a/library/src/dump.h
+++ b/library/src/dump.h
@@ -12,6 +12,7 @@
 
 #include "dds/dds.h"
 #include "moves/Moves.h"
+#include "system/SolverContext.h"
 #include "system/Memory.h"
 #include "trans_table/TransTable.h" // for nodeCardsType and enums
 
@@ -44,6 +45,15 @@ void DumpStored(
   ofstream& fout,
   const pos& tpos,
   const Moves& moves,
+  const nodeCardsType& node,
+  const int target,
+  const int depth);
+
+// Convenience overload to avoid direct Moves exposure at call sites
+void DumpStored(
+  ofstream& fout,
+  const pos& tpos,
+  SolverContext& ctx,
   const nodeCardsType& node,
   const int target,
   const int depth);

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -303,3 +303,10 @@ void SolverContext::MoveGenContext::MakeSpecific(
 {
   thr_->moves.MakeSpecific(mply, trick, relHand);
 }
+
+void SolverContext::MoveGenContext::Reinit(
+  const int tricks,
+  const int leadHand)
+{
+  thr_->moves.Reinit(tricks, leadHand);
+}

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -310,3 +310,16 @@ void SolverContext::MoveGenContext::Reinit(
 {
   thr_->moves.Reinit(tricks, leadHand);
 }
+
+void SolverContext::MoveGenContext::Init(
+  const int tricks,
+  const int relStartHand,
+  const int initialRanks[],
+  const int initialSuits[],
+  const unsigned short rankInSuit[DDS_HANDS][DDS_SUITS],
+  const int trump,
+  const int leadHand)
+{
+  thr_->moves.Init(tricks, relStartHand, initialRanks, initialSuits,
+                   rankInSuit, trump, leadHand);
+}

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -304,6 +304,11 @@ void SolverContext::MoveGenContext::MakeSpecific(
   thr_->moves.MakeSpecific(mply, trick, relHand);
 }
 
+std::string SolverContext::MoveGenContext::TrickToText(const int trick) const
+{
+  return thr_->moves.TrickToText(trick);
+}
+
 void SolverContext::MoveGenContext::Reinit(
   const int tricks,
   const int leadHand)

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -263,6 +263,13 @@ const moveType* SolverContext::MoveGenContext::MakeNext(
   return thr_->moves.MakeNext(trick, relHand, winRanks);
 }
 
+const moveType* SolverContext::MoveGenContext::MakeNextSimple(
+  const int trick,
+  const int relHand)
+{
+  return thr_->moves.MakeNextSimple(trick, relHand);
+}
+
 int SolverContext::MoveGenContext::GetLength(
   const int trick,
   const int relHand) const

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -323,3 +323,13 @@ void SolverContext::MoveGenContext::Init(
   thr_->moves.Init(tricks, relStartHand, initialRanks, initialSuits,
                    rankInSuit, trump, leadHand);
 }
+
+void SolverContext::MoveGenContext::PrintTrickStats(std::ofstream& fout) const
+{
+  thr_->moves.PrintTrickStats(fout);
+}
+
+void SolverContext::MoveGenContext::PrintFunctionStats(std::ofstream& fout) const
+{
+  thr_->moves.PrintFunctionStats(fout);
+}

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -290,3 +290,8 @@ void SolverContext::MoveGenContext::RegisterHit(
 {
   thr_->moves.RegisterHit(tricks, relHand);
 }
+
+const trickDataType& SolverContext::MoveGenContext::GetTrickData(const int tricks)
+{
+  return thr_->moves.GetTrickData(tricks);
+}

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -227,3 +227,59 @@ double ThreadMemoryUsed()
 
   return memUsed;
 }
+
+// --- MoveGenContext out-of-line definitions ---
+int SolverContext::MoveGenContext::MoveGen0(
+  const int tricks,
+  const pos& tpos,
+  const moveType& bestMove,
+  const moveType& bestMoveTT,
+  const relRanksType thrp_rel[])
+{
+  return thr_->moves.MoveGen0(tricks, tpos, bestMove, bestMoveTT, thrp_rel);
+}
+
+int SolverContext::MoveGenContext::MoveGen123(
+  const int tricks,
+  const int relHand,
+  const pos& tpos)
+{
+  return thr_->moves.MoveGen123(tricks, relHand, tpos);
+}
+
+void SolverContext::MoveGenContext::Purge(
+  const int tricks,
+  const int relHand,
+  const moveType forbiddenMoves[])
+{
+  thr_->moves.Purge(tricks, relHand, forbiddenMoves);
+}
+
+const moveType* SolverContext::MoveGenContext::MakeNext(
+  const int trick,
+  const int relHand,
+  const unsigned short winRanks[])
+{
+  return thr_->moves.MakeNext(trick, relHand, winRanks);
+}
+
+int SolverContext::MoveGenContext::GetLength(
+  const int trick,
+  const int relHand) const
+{
+  return thr_->moves.GetLength(trick, relHand);
+}
+
+void SolverContext::MoveGenContext::Rewind(
+  const int tricks,
+  const int relHand)
+{
+  thr_->moves.Rewind(tricks, relHand);
+}
+
+void SolverContext::MoveGenContext::RegisterHit(
+  const int tricks,
+  const int relHand)
+{
+  thr_->moves.RegisterHit(tricks, relHand);
+}

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -333,3 +333,8 @@ void SolverContext::MoveGenContext::PrintFunctionStats(std::ofstream& fout) cons
 {
   thr_->moves.PrintFunctionStats(fout);
 }
+
+void SolverContext::MoveGenContext::PrintTrickDetails(std::ofstream& fout) const
+{
+  thr_->moves.PrintTrickDetails(fout);
+}

--- a/library/src/system/SolverContext.cpp
+++ b/library/src/system/SolverContext.cpp
@@ -295,3 +295,11 @@ const trickDataType& SolverContext::MoveGenContext::GetTrickData(const int trick
 {
   return thr_->moves.GetTrickData(tricks);
 }
+
+void SolverContext::MoveGenContext::MakeSpecific(
+  const moveType& mply,
+  const int trick,
+  const int relHand)
+{
+  thr_->moves.MakeSpecific(mply, trick, relHand);
+}

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -152,7 +152,8 @@ public:
       const int trump,
       const int leadHand);
 
-    // Diagnostics (no behavior change; passthrough to Moves)
+  // Diagnostics (no behavior change; passthrough to Moves)
+  // Note: Emission is controlled by DDS_MOVES / DDS_MOVES_DETAILS.
     void PrintTrickStats(std::ofstream& fout) const;
   void PrintTrickDetails(std::ofstream& fout) const;
     void PrintFunctionStats(std::ofstream& fout) const;

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -142,6 +142,16 @@ public:
       const int tricks,
       const int leadHand);
 
+    // Initialize move generation state for a given trick and starting hand
+    void Init(
+      const int tricks,
+      const int relStartHand,
+      const int initialRanks[],
+      const int initialSuits[],
+      const unsigned short rankInSuit[DDS_HANDS][DDS_SUITS],
+      const int trump,
+      const int leadHand);
+
     // Read-only access to per-trick generated metadata
     const trickDataType& GetTrickData(const int tricks);
 

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -137,6 +137,11 @@ public:
       const int tricks,
       const int relHand);
 
+    // Reinitialize move generation for a new lead hand at a given trick
+    void Reinit(
+      const int tricks,
+      const int leadHand);
+
     // Read-only access to per-trick generated metadata
     const trickDataType& GetTrickData(const int tricks);
 

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -152,6 +152,10 @@ public:
       const int trump,
       const int leadHand);
 
+    // Diagnostics (no behavior change; passthrough to Moves)
+    void PrintTrickStats(std::ofstream& fout) const;
+    void PrintFunctionStats(std::ofstream& fout) const;
+
     // Read-only access to per-trick generated metadata
     const trickDataType& GetTrickData(const int tricks);
 

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -16,6 +16,7 @@ struct moveType;       // from dds/dds.h
 struct WinnersType;    // from dds/dds.h
 struct pos;            // from dds/dds.h
 struct relRanksType;   // from dds/dds.h
+struct trickDataType;  // from data_types/dds.h
 #include "trans_table/TransTable.h" // ensure complete type and enums
 
 // Minimal configuration scaffold for future expansion.
@@ -135,6 +136,9 @@ public:
     void RegisterHit(
       const int tricks,
       const int relHand);
+
+    // Read-only access to per-trick generated metadata
+    const trickDataType& GetTrickData(const int tricks);
 
   private:
     ThreadData* thr_ = nullptr;

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -155,7 +155,7 @@ public:
   // Diagnostics (no behavior change; passthrough to Moves)
   // Note: Emission is controlled by DDS_MOVES / DDS_MOVES_DETAILS.
     void PrintTrickStats(std::ofstream& fout) const;
-  void PrintTrickDetails(std::ofstream& fout) const;
+    void PrintTrickDetails(std::ofstream& fout) const;
     void PrintFunctionStats(std::ofstream& fout) const;
 
     // Read-only access to per-trick generated metadata

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -162,7 +162,7 @@ public:
     const trickDataType& GetTrickData(const int tricks);
 
  // Read-only textual dump helper
-  std::string TrickToText(const int trick) const;
+    std::string TrickToText(const int trick) const;
 
     // Specify a particular move at a trick/hand position
     void MakeSpecific(

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -154,6 +154,7 @@ public:
 
     // Diagnostics (no behavior change; passthrough to Moves)
     void PrintTrickStats(std::ofstream& fout) const;
+  void PrintTrickDetails(std::ofstream& fout) const;
     void PrintFunctionStats(std::ofstream& fout) const;
 
     // Read-only access to per-trick generated metadata

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -161,6 +161,9 @@ public:
     // Read-only access to per-trick generated metadata
     const trickDataType& GetTrickData(const int tricks);
 
+  // Read-only textual dump helper
+  std::string TrickToText(const int trick) const;
+
     // Specify a particular move at a trick/hand position
     void MakeSpecific(
       const moveType& mply,

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -161,7 +161,7 @@ public:
     // Read-only access to per-trick generated metadata
     const trickDataType& GetTrickData(const int tricks);
 
-  // Read-only textual dump helper
+ // Read-only textual dump helper
   std::string TrickToText(const int trick) const;
 
     // Specify a particular move at a trick/hand position

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -119,6 +119,11 @@ public:
       const int relHand,
       const unsigned short winRanks[]);
 
+    // Simpler variant without winRanks used in several SolverIF paths
+    const moveType* MakeNextSimple(
+      const int trick,
+      const int relHand);
+
     int GetLength(
       const int trick,
       const int relHand) const;

--- a/library/src/system/SolverContext.h
+++ b/library/src/system/SolverContext.h
@@ -140,6 +140,12 @@ public:
     // Read-only access to per-trick generated metadata
     const trickDataType& GetTrickData(const int tricks);
 
+    // Specify a particular move at a trick/hand position
+    void MakeSpecific(
+      const moveType& mply,
+      const int trick,
+      const int relHand);
+
   private:
     ThreadData* thr_ = nullptr;
   };


### PR DESCRIPTION
Summary\n- Encapsulates move generation behind SolverContext::MoveGenContext with no behavior changes.\n- Routed call sites: MoveGen0/123, Purge, MakeNext/MakeNextSimple, GetLength/Rewind, RegisterHit, GetTrickData, MakeSpecific, Reinit, Init.\n- Diagnostics through facade: PrintTrickStats, PrintTrickDetails, PrintFunctionStats.\n- Added TrickToText facade and DumpStored(ctx) overload; updated ABsearch to use ctx overload.\n- Reset semantics unchanged (from earlier Task 05); search-state already behind SearchContext.\n\nVerification\n- Bazel debug tests: 14/14 PASS across slices.\n- No functional differences intended; dtest previously validated during Task 05.\n\nNotes\n- Kept changes mechanical; minimal footprint per slice.\n- Forwarders for Step/Reward/Sort/PrintMoves intentionally deferred until a concrete usage appears.\n\nScope\n- Branch: refactor/dynamic_environment_part_eleven\n- Base: mn_main